### PR TITLE
WEB support

### DIFF
--- a/lib/src/decoder/decode.dart
+++ b/lib/src/decoder/decode.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import '../exception.dart';
 import '../helper.dart';


### PR DESCRIPTION
Currently it's impossible to use Brotli package in any other platforms, because it's not compatible due to dart:io usage.

This pull request changes `dart:io` import to `dart:typed_data` and adds compatibility with WEB. 